### PR TITLE
Use docker multistage builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,21 @@
-FROM golang:1.8.0-alpine
+FROM golang:1.8.0-alpine as build
 LABEL maintainer "Infinity Works"
 
-EXPOSE 9171
-
-ENV GOPATH=/go
-ENV LISTEN_PORT=9171
-
-RUN addgroup exporter \
-     && adduser -S -G exporter exporter \
-     && apk --update add ca-certificates \
+RUN apk --update add ca-certificates \
      && apk --update add --virtual build-deps git
-
 COPY ./ /go/src/github.com/infinityworksltd/github-exporter
-
 WORKDIR /go/src/github.com/infinityworksltd/github-exporter
-
 RUN go get \
  && go test ./... \
  && go build -o /bin/main
 
-USER exporter
+FROM alpine:3.6
 
-CMD [ "/bin/main" ]
+RUN apk --update add ca-certificates \
+     && addgroup exporter \
+     && adduser -S -G exporter exporter
+USER exporter
+COPY --from=build /bin/main /bin/main
+ENV LISTEN_PORT=9171
+EXPOSE 9171
+ENTRYPOINT [ "/bin/main" ]


### PR DESCRIPTION
Hi folks,

First of all thanks for your amazing job ! 
I just noticed your image is around 100mb for a single go binary.
Using a multistage build I managed to reduce it to 11.6mb, so I thought I should share it :)

(We could gain a few mb more by using a scratch image and disabling CGO support at build time, but it means no user management)

WDYT ?
Cheers !