### PR TITLE
bump version, change --no-cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM golang:1.8.0-alpine as build
+FROM golang:1.9-alpine as build
 LABEL maintainer "Infinity Works"
 
-RUN apk --update add ca-certificates \
-     && apk --update add --virtual build-deps git
+RUN apk --no-cache add ca-certificates \
+     && apk --no-cache add --virtual build-deps git
 
 COPY ./ /go/src/github.com/infinityworks/github-exporter
 WORKDIR /go/src/github.com/infinityworks/github-exporter
@@ -13,7 +13,7 @@ RUN go get \
 
 FROM alpine:3.6
 
-RUN apk --update add ca-certificates \
+RUN apk --no-cache add ca-certificates \
      && addgroup exporter \
      && adduser -S -G exporter exporter
 USER exporter


### PR DESCRIPTION
bump version of golang to 1.9 and change builder image to --no-cache.

IMHO no need to keep the package cache.  so there is then also no need to clean the 
/var/cache/apk/* folder which i would have added when you want to keep the --update.

All the best,

Benjamin