### PR TITLE
Trim whitespace when reading token from file.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -109,7 +109,7 @@ func getAuth(token string, tokenFile string) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		return string(b), err
+		return strings.TrimLeft(string(b)), err
 
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -109,7 +109,7 @@ func getAuth(token string, tokenFile string) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		return strings.TrimLeft(string(b)), err
+		return strings.TrimSpace(string(b)), err
 
 	}
 


### PR DESCRIPTION
Reading files often have a `\n` at the end.

GitHub doesn't issue or accept any new lines in tokens so this should  not break anything.

As you can see below this causes issues, especially when using Docker secrets you'd normally add them like `echo "secret" | docker secret create github_token -` yet there is a `\n` added by `echo` without `-n` which isn't normally remembered making the following easy and frustraiting:

```
time="2017-12-27T21:29:42Z" level=error msg="Error scraping API, Error: Error converting body to byte array: Get https://api.github.com/orgs/legalweb/repos?&per_page=100: net/http: invalid header field value \"token notarealtokennotarealtoken\\n\" for key Authorization"
```