### PR TITLE
handle http error before closing the body

### DIFF
--- a/exporter/gather.go
+++ b/exporter/gather.go
@@ -56,12 +56,10 @@ func getRates(baseURL string, token string) (*RateLimits, error) {
 	url := fmt.Sprintf("%s%s", baseURL, rateEndPoint)
 
 	resp, err := getHTTPResponse(url, token)
-
-	defer resp.Body.Close()
-
 	if err != nil {
 		return &RateLimits{}, err
 	}
+	defer resp.Body.Close()
 
 	// Triggers if rate-limiting isn't enabled on private Github Enterprise installations
 	if resp.StatusCode == 404 {


### PR DESCRIPTION
This should help with this:
panic: runtime error: invalid memory address or nil pointer dereference

See example in the http docs:
https://golang.org/pkg/net/http/

> The client must close the response body when finished with it:

```
resp, err := http.Get("http://example.com/")
if err != nil {
	// handle error
}
defer resp.Body.Close()
body, err := ioutil.ReadAll(resp.Body)
// ...
```