### PR TITLE
Improve error handling

### DIFF
--- a/exporter/http.go
+++ b/exporter/http.go
@@ -96,16 +96,14 @@ func getResponse(url string, token string, ch chan<- *Response) error {
 	log.Infof("Fetching %s \n", url)
 
 	resp, err := getHTTPResponse(url, token) // do this earlier
-
 	if err != nil {
-		return fmt.Errorf("Error converting body to byte array: %v", err)
+		return fmt.Errorf("Error fetching http response: %v", err)
 	}
+	defer resp.Body.Close()
+
 
 	// Read the body to a byte array so it can be used elsewhere
 	body, err := ioutil.ReadAll(resp.Body)
-
-	defer resp.Body.Close()
-
 	if err != nil {
 		return fmt.Errorf("Error converting body to byte array: %v", err)
 	}

--- a/exporter/http.go
+++ b/exporter/http.go
@@ -60,6 +60,7 @@ func paginateTargets(targets []string, token string) []string {
 		resp, err := getHTTPResponse(url, token)
 		if err != nil {
 			log.Errorf("Error retrieving Link headers, Error: %s", err)
+			continue
 		}
 
 		if resp.Header["Link"] != nil {


### PR DESCRIPTION
This fixes the following by skipping the target:

```
 level=error msg="Error retrieving Link headers, Error: Get https://api.github.com/repos/XXXX?&per_page=100: net/http: request canceled (Client.Timeout exceeded while awaiting headers)"
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x38 pc=0x755810]

goroutine 359851 [running]:
github.com/infinityworks/github-exporter/exporter.paginateTargets(0xc420138000, 0xd, 0x10, 0xc42001e00d, 0x28, 0x0, 0x3, 0x0)
	/go/src/github.com/infinityworks/github-exporter/exporter/http.go:65 +0x170
github.com/infinityworks/github-exporter/exporter.asyncHTTPGets(0xc420138000, 0xd, 0x10, 0xc42001e00d, 0x28, 0xc4207162d8, 0xc4201aefc0, 0xc4201aef9e, 0x0, 0xc4201aef98)
	/go/src/github.com/infinityworks/github-exporter/exporter/http.go:17 +0x74
github.com/infinityworks/github-exporter/exporter.(*Exporter).gatherData(0xc420084fa0, 0x1, 0x1, 0xc4201aee78, 0x6a780f, 0xc420060120, 0x82d7d4)
	/go/src/github.com/infinityworks/github-exporter/exporter/gather.go:16 +0x91
github.com/infinityworks/github-exporter/exporter.(*Exporter).Collect(0xc420084fa0, 0xc4205d6060)
	/go/src/github.com/infinityworks/github-exporter/exporter/prometheus.go:22 +0x40
github.com/prometheus/client_golang/prometheus.(*Registry).Gather.func1()
	/go/src/github.com/prometheus/client_golang/prometheus/registry.go:434 +0x1b3
created by github.com/prometheus/client_golang/prometheus.(*Registry).Gather
	/go/src/github.com/prometheus/client_golang/prometheus/registry.go:445 +0x5ac
```

It also moves another body.Close() to an earlier stage.