### PR TITLE
Scrape release metrics from repositories

### DIFF
--- a/METRICS.md
+++ b/METRICS.md
@@ -27,6 +27,8 @@ github_repo_stars{archived="false",fork="false",language="Go",license="mit",priv
 # HELP github_repo_watchers Total number of watchers/subscribers for given repository
 # TYPE github_repo_watchers gauge
 github_repo_watchers{archived="false",fork="false",language="Go",license="mit",private="false",repo="github-exporter",user="infinityworks"} 10
+# TYPE github_repo_release_downloads gauge
+github_repo_release_downloads{name="release1.0.0",repo="github-exporter",user="infinityworks"} 3500
 ```
 
 <!--

--- a/exporter/metrics.go
+++ b/exporter/metrics.go
@@ -37,7 +37,7 @@ func AddMetrics() map[string]*prometheus.Desc {
 	APIMetrics["ReleaseDownloads"] = prometheus.NewDesc(
 		prometheus.BuildFQName("github", "repo", "release_downloads"),
 		"Download count for a given release",
-		[]string{"repo", "user", "name"}, nil,
+		[]string{"repo", "user", "release", "name", "created_at"}, nil,
 	)
 	APIMetrics["Limit"] = prometheus.NewDesc(
 		prometheus.BuildFQName("github", "rate", "limit"),
@@ -71,7 +71,7 @@ func (e *Exporter) processMetrics(data []*Datum, rates *RateLimits, ch chan<- pr
 
 		for _, release := range x.Releases {
 			for _, asset := range release.Assets {
-				ch <- prometheus.MustNewConstMetric(e.APIMetrics["ReleaseDownloads"], prometheus.GaugeValue, float64(asset.Downloads), x.Name, x.Owner.Login, asset.Name)
+				ch <- prometheus.MustNewConstMetric(e.APIMetrics["ReleaseDownloads"], prometheus.GaugeValue, float64(asset.Downloads), x.Name, x.Owner.Login, release.Name, asset.Name, asset.CreatedAt)
 			}
 		}
 	}

--- a/exporter/structs.go
+++ b/exporter/structs.go
@@ -28,15 +28,27 @@ type Datum struct {
 	License struct {
 		Key string `json:"key"`
 	} `json:"license"`
-	Language   string  `json:"language"`
-	Archived   bool    `json:"archived"`
-	Private    bool    `json:"private"`
-	Fork       bool    `json:"fork"`
-	Forks      float64 `json:"forks"`
-	Stars      float64 `json:"stargazers_count"`
-	OpenIssues float64 `json:"open_issues"`
-	Watchers   float64 `json:"subscribers_count"`
-	Size       float64 `json:"size"`
+	Language   string    `json:"language"`
+	Archived   bool      `json:"archived"`
+	Private    bool      `json:"private"`
+	Fork       bool      `json:"fork"`
+	Forks      float64   `json:"forks"`
+	Stars      float64   `json:"stargazers_count"`
+	OpenIssues float64   `json:"open_issues"`
+	Watchers   float64   `json:"subscribers_count"`
+	Size       float64   `json:"size"`
+	Releases   []Release
+}
+
+type Release struct {
+	Name   string  `json:"name"`
+	Assets []Asset `json:"assets"`
+}
+
+type Asset struct {
+	Name      string  `json:"name"`
+	Size      int64 `json:"size"`
+	Downloads int32 `json:"download_count"`
 }
 
 // RateLimits is used to store rate limit data into a struct

--- a/exporter/structs.go
+++ b/exporter/structs.go
@@ -46,9 +46,10 @@ type Release struct {
 }
 
 type Asset struct {
-	Name      string  `json:"name"`
-	Size      int64 `json:"size"`
-	Downloads int32 `json:"download_count"`
+	Name      string `json:"name"`
+	Size      int64  `json:"size"`
+	Downloads int32  `json:"download_count"`
+	CreatedAt string `json:"created_at"`
 }
 
 // RateLimits is used to store rate limit data into a struct

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/infinityworks/github-exporter/exporter"
 	"github.com/infinityworks/go-common/logger"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
 )
 
@@ -37,7 +38,7 @@ func main() {
 	prometheus.MustRegister(&exporter)
 
 	// Setup HTTP handler
-	http.Handle(applicationCfg.MetricsPath(), prometheus.Handler())
+	http.Handle(applicationCfg.MetricsPath(), promhttp.Handler())
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(`<html>
 		                <head><title>Github Exporter</title></head>


### PR DESCRIPTION
- Fixed prometheus HTTP handler, as the current build is broken by this bug.

- Add `downloads` metric for releases.
```
# TYPE github_repo_release_downloads gauge
github_repo_release_downloads{name="release-1.0.0",repo="github-exporter",user="infinityworks"} 3500
```