### PR TITLE
Allow to specify no targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,12 @@ Exposes basic metrics for your repositories from the GitHub API, to a Prometheus
 
 ## Configuration
 
-This exporter is setup to take input from environment variables:
+This exporter is setup to take input from environment variables. All variables are optional:
 
-### Required
 * `ORGS` If supplied, the exporter will enumerate all repositories for that organization. Expected in the format "org1, org2".
 * `REPOS` If supplied, The repos you wish to monitor, expected in the format "user/repo1, user/repo2". Can be across different Github users/orgs.
 * `USERS` If supplied, the exporter will enumerate all repositories for that users. Expected in
 the format "user1, user2".
-
-At least one of those 3 options should be provided.
-
-### Optional
 * `GITHUB_TOKEN` If supplied, enables the user to supply a github authentication token that allows the API to be queried more often. Optional, but recommended.
 * `GITHUB_TOKEN_FILE` If supplied _instead of_ `GITHUB_TOKEN`, enables the user to supply a path to a file containing a github authentication token that allows the API to be queried more often. Optional, but recommended.
 * `API_URL` Github API URL, shouldn't need to change this. Defaults to `https://api.github.com`

--- a/config/config.go
+++ b/config/config.go
@@ -65,9 +65,8 @@ func getScrapeURLs(apiURL, repos, orgs, users string) ([]string, error) {
 
 	opts := "?&per_page=100" // Used to set the Github API to return 100 results per page (max)
 
-	// User input validation, check that either repositories or organisations have been passed in
 	if len(repos) == 0 && len(orgs) == 0 && len(users) == 0 {
-		return urls, fmt.Errorf("No targets specified")
+		log.Info("No targets specified. Only rate limit endpoint will be scraped")
 	}
 
 	// Append repositories to the array

--- a/exporter/gather.go
+++ b/exporter/gather.go
@@ -10,14 +10,14 @@ import (
 )
 
 // gatherData - Collects the data from the API and stores into struct
-func (e *Exporter) gatherData() ([]*Datum, *RateLimits, error) {
+func (e *Exporter) gatherData() ([]*Datum, error) {
 
 	data := []*Datum{}
 
 	responses, err := asyncHTTPGets(e.TargetURLs, e.APIToken)
 
 	if err != nil {
-		return data, nil, err
+		return data, err
 	}
 
 	for _, response := range responses {
@@ -46,26 +46,19 @@ func (e *Exporter) gatherData() ([]*Datum, *RateLimits, error) {
 		log.Infof("API data fetched for repository: %s", response.url)
 	}
 
-	// Check the API rate data and store as a metric
-	rates, err := getRates(e.APIURL, e.APIToken)
-
-	if err != nil {
-		log.Errorf("Unable to obtain rate limit data from API, Error: %s", err)
-	}
-
 	//return data, rates, err
-	return data, rates, nil
+	return data, nil
 
 }
 
 // getRates obtains the rate limit data for requests against the github API.
 // Especially useful when operating without oauth and the subsequent lower cap.
-func getRates(baseURL string, token string) (*RateLimits, error) {
+func (e *Exporter) getRates() (*RateLimits, error) {
 
 	rateEndPoint := ("/rate_limit")
-	url := fmt.Sprintf("%s%s", baseURL, rateEndPoint)
+	url := fmt.Sprintf("%s%s", e.APIURL, rateEndPoint)
 
-	resp, err := getHTTPResponse(url, token)
+	resp, err := getHTTPResponse(url, e.APIToken)
 	if err != nil {
 		return &RateLimits{}, err
 	}

--- a/exporter/prometheus.go
+++ b/exporter/prometheus.go
@@ -18,11 +18,20 @@ func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
 // This function is called when a scrape is peformed on the /metrics page
 func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 
+	data := []*Datum{}
+	var err error
 	// Scrape the Data from Github
-	var data, rates, err = e.gatherData()
+	if len(e.TargetURLs) > 0 {
+		data, err = e.gatherData()
+		if err != nil {
+			log.Errorf("Error gathering Data from remote API: %v", err)
+			return
+		}
+	}
 
+	rates, err := e.getRates()
 	if err != nil {
-		log.Errorf("Error gathering Data from remote API: %v", err)
+		log.Errorf("Error gathering Rates from remote API: %v", err)
 		return
 	}
 


### PR DESCRIPTION
In order to query only rate limits. Querying targets reduces
the remaining rate limits. This should be avoided if the rate limit
is the only information of interest.