### PR TITLE
Refactored github-exporter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 .sequence
+.vscode/
+build/
+/github-exporter
+
+.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,13 @@
-.PHONY: install test build
+BINARY_NAME := github-exporter
+DOCKER_REPO ?= infinityworks/github-exporter
+ARCH ?= darwin
+GOBUILD_VERSION_ARGS := ""
+TAG := $(shell cat VERSION)
+
+
+.PHONY: install test build docker
+
+all: build
 
 install:
 	@go mod download
@@ -6,5 +15,8 @@ install:
 test:
 	@go test -v -race ./...
 
-build:
-	@go build ./...
+build: *.go
+	@go build -v -o build/bin/$(ARCH)/$(BINARY_NAME) $(GOBUILD_VERSION_ARGS)
+
+docker:
+	docker build -t ${DOCKER_REPO}:$(TAG) .

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ This exporter is setup to take input from environment variables. All variables a
 
 * `ORGS` If supplied, the exporter will enumerate all repositories for that organization. Expected in the format "org1, org2".
 * `REPOS` If supplied, The repos you wish to monitor, expected in the format "user/repo1, user/repo2". Can be across different Github users/orgs.
+* `PR_QUERY_OPTIONS` if supplied, added as [query options](https://docs.github.com/en/rest/reference/pulls#list-pull-requests) to list pulls request.
+* `PR_LONG_RUNNING_TIME_DIFF` Time threshold in hours beyond which PRs are considered long running. Default is 2 weeks ie 336 hours.
 * `USERS` If supplied, the exporter will enumerate all repositories for that users. Expected in
 the format "user1, user2".
 * `GITHUB_TOKEN` If supplied, enables the user to supply a github authentication token that allows the API to be queried more often. Optional, but recommended.
@@ -50,6 +52,8 @@ github-exporter:
 
 ```
 
+## Kubernetes deployment
+Follow the instructions provided in [README.md](helm/github-exporter/README.md)
 ## Metrics
 
 Metrics will be made available on port 9171 by default

--- a/exporter/structs.go
+++ b/exporter/structs.go
@@ -2,6 +2,7 @@ package exporter
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/infinityworks/github-exporter/config"
 	"github.com/prometheus/client_golang/prometheus"
@@ -46,11 +47,16 @@ type Release struct {
 	Assets []Asset `json:"assets"`
 }
 
+// Pull define PR request stats
 type Pull struct {
 	Url  string `json:"url"`
 	User struct {
 		Login string `json:"login"`
 	} `json:"user"`
+	Number     int       `json:"number"`
+	State      string    `json:"state"`
+	CreaatedAt time.Time `json:"created_at"`
+	UpdateddAt time.Time `json:"updated_at"`
 }
 
 type Asset struct {

--- a/helm/github-exporter/.helmignore
+++ b/helm/github-exporter/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/github-exporter/Chart.yaml
+++ b/helm/github-exporter/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: github-exporter
+description: GitHub metrics exporter for Prometheus
+
+maintainers: 
+  - name: Dimitar Georgievski
+    email: dgeorgievski@gmail.com
+
+type: application
+
+version: 0.1.0
+
+appVersion: 1.0.2

--- a/helm/github-exporter/README.md
+++ b/helm/github-exporter/README.md
@@ -1,0 +1,14 @@
+# github-exporter helm chart
+
+# Deployment
+```
+cd github-exporter/helm
+
+helm upgrade \
+github-exporter github-exporter/ \
+--install \
+--namespace=exporters \
+-f helm_vars/nonprod/values.yaml \
+--debug --dry-run
+
+```

--- a/helm/github-exporter/templates/NOTES.txt
+++ b/helm/github-exporter/templates/NOTES.txt
@@ -1,0 +1,21 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "github-exporter.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "github-exporter.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "github-exporter.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "github-exporter.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:80
+{{- end }}

--- a/helm/github-exporter/templates/_helpers.tpl
+++ b/helm/github-exporter/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "github-exporter.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "github-exporter.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "github-exporter.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "github-exporter.labels" -}}
+helm.sh/chart: {{ include "github-exporter.chart" . }}
+{{ include "github-exporter.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "github-exporter.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "github-exporter.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "github-exporter.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "github-exporter.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm/github-exporter/templates/deployment.yaml
+++ b/helm/github-exporter/templates/deployment.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "github-exporter.fullname" . }}
+  labels:
+    {{- include "github-exporter.labels" . | nindent 4 }}
+spec:
+{{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+{{- end }}
+  selector:
+    matchLabels:
+      {{- include "github-exporter.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+    {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      labels:
+        {{- include "github-exporter.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "github-exporter.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+      {{- if gt (len .Values.envVars) 0 }}
+          env:
+          {{- range $i,$e := .Values.envVars }}
+            - name: {{ $e.name }}
+              value: {{ $e.value | quote }}
+          {{- end }}
+      {{- end }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 9171
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/github-exporter/templates/hpa.yaml
+++ b/helm/github-exporter/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "github-exporter.fullname" . }}
+  labels:
+    {{- include "github-exporter.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "github-exporter.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+  {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+  {{- end }}
+  {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+  {{- end }}
+{{- end }}

--- a/helm/github-exporter/templates/ingress.yaml
+++ b/helm/github-exporter/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "github-exporter.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "github-exporter.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+  {{- end }}

--- a/helm/github-exporter/templates/service.yaml
+++ b/helm/github-exporter/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "github-exporter.fullname" . }}
+  labels:
+    {{- include "github-exporter.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "github-exporter.selectorLabels" . | nindent 4 }}

--- a/helm/github-exporter/templates/serviceaccount.yaml
+++ b/helm/github-exporter/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "github-exporter.serviceAccountName" . }}
+  labels:
+    {{- include "github-exporter.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm/github-exporter/templates/servicemonitor.yaml
+++ b/helm/github-exporter/templates/servicemonitor.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.prometheus.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "github-exporter.fullname" . }}
+  namespace: {{ .Values.prometheus.serviceMonitor.namespace }}
+  labels:
+    app: {{ template "github-exporter.name" . }}
+    release: kube-prometheus-stack
+{{ include "github-exporter.labels" . | indent 4 }}
+spec:
+  endpoints:
+  - path: /metrics
+    port: http
+  namespaceSelector:
+    matchNames:
+    - exporters
+  selector:
+    matchLabels:
+      {{- include "github-exporter.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/helm/github-exporter/templates/tests/test-connection.yaml
+++ b/helm/github-exporter/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "github-exporter.fullname" . }}-test-connection"
+  labels:
+    {{- include "github-exporter.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "github-exporter.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/helm/github-exporter/values.yaml
+++ b/helm/github-exporter/values.yaml
@@ -1,0 +1,93 @@
+# Default values for github-exporter.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: dgeorgievski/github-exporter
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 9171
+
+prometheus:
+  serviceMonitor:
+    enabled: false 
+    namespace: monitoring
+
+envVars: []
+  # - name: GITHUB_TOKEN
+  #   value: 
+  # - name: REPOS 
+  #   value: "org/repo1, org/repo2, ..."
+  # - name: PR_QUERY_OPTIONS
+  #   value: "GitHub API /pull query options"
+
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths: []
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/helm/helm_vars/nonprod/values.yaml
+++ b/helm/helm_vars/nonprod/values.yaml
@@ -1,0 +1,20 @@
+replicaCount: 1
+
+image:
+  repository: dgeorgievski/github-exporter
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "1.0.2"
+
+prometheus:
+  serviceMonitor:
+    enabled: false
+    namespace: monitoring
+
+envVars:
+  - name: GITHUB_TOKEN
+    value: "Your GH API token here"
+  - name: REPOS 
+    value: "infinityworks/github-exporter"
+  - name: PR_QUERY_OPTIONS
+    value: "per_page=100&sort=long-running&direction=descending"

--- a/test/github_exporter_test.go
+++ b/test/github_exporter_test.go
@@ -2,16 +2,17 @@ package test
 
 import (
 	"fmt"
-	"github.com/infinityworks/github-exporter/config"
-	"github.com/infinityworks/github-exporter/exporter"
-	web "github.com/infinityworks/github-exporter/http"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/steinfletcher/apitest"
 	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/infinityworks/github-exporter/config"
+	"github.com/infinityworks/github-exporter/exporter"
+	web "github.com/infinityworks/github-exporter/http"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/steinfletcher/apitest"
 )
 
 func TestHomepage(t *testing.T) {
@@ -41,8 +42,11 @@ func TestGithubExporter(t *testing.T) {
 		Assert(bodyContains(`github_rate_remaining 60`)).
 		Assert(bodyContains(`github_rate_reset 1.566853865e+09`)).
 		Assert(bodyContains(`github_repo_forks{archived="false",fork="false",language="Go",license="mit",private="false",repo="myRepo",user="myOrg"} 10`)).
-		Assert(bodyContains(`github_repo_pull_request_count{repo="myRepo"} 3`)).
-		Assert(bodyContains(`github_repo_open_issues{archived="false",fork="false",language="Go",license="mit",private="false",repo="myRepo",user="myOrg"} 2`)).
+		// Assert(bodyContains(`github_repo_pull_request_count{repo="myRepo"} 3`)).
+		Assert(bodyContains(`github_repo_open_issues{archived="false",fork="false",language="Go",license="mit",private="false",repo="myRepo",user="myOrg"} 5`)).
+		// Assert(bodyContains(`github_repo_pull_request_count{repo="myRepo",user="myOrg",language="Go"} 3`)).
+		Assert(bodyContains(`github_repo_pull_request_count{language="Go",repo="myRepo",user="myOrg"} 3`)).
+		Assert(bodyContains(`github_repo_pull_request_long_running_count{language="Go",repo="myRepo",user="myOrg"} 3`)).
 		Assert(bodyContains(`github_repo_size_kb{archived="false",fork="false",language="Go",license="mit",private="false",repo="myRepo",user="myOrg"} 946`)).
 		Assert(bodyContains(`github_repo_stars{archived="false",fork="false",language="Go",license="mit",private="false",repo="myRepo",user="myOrg"} 120`)).
 		Assert(bodyContains(`github_repo_watchers{archived="false",fork="false",language="Go",license="mit",private="false",repo="myRepo",user="myOrg"} 5`)).


### PR DESCRIPTION
I've been evaluating `github-exporter`  at wiley.com as part of our strategy to adopt Prometheus and Cortex as scalable enterprise services for monitoring in the cloud.

We are interested to use github-exporter and love to contribute to this project, but considering the scope of this PR I wanted to follow up first with a personal PR.

**Changes**
------------------------
**OpenIssues** 
In the current form OpenIssues counts the non-PR issues,
https://github.com/infinityworks/github-exporter/blob/master/exporter/metrics.go#L80-L83

According to GitHub definition OpenIssues is a sum of PRs + non-PR issues.
https://docs.github.com/en/rest/reference/issues

> Note: GitHub's REST API v3 considers every pull request an issue, but not every issue is a pull request. For this reason, "Issues" endpoints may return both issues and pull requests in the response. 

**Querying PRs**

- Incorrect paging
In the current form only page 0 is collected which contributes to incorrect PR reporting as soon as the repo has more PRs than the default page size returned by GH. I believe the default is 30.
https://github.com/infinityworks/github-exporter/blob/master/exporter/gather.go#L121

**Additions**
------------------------
**Querying PRs**
- Added new options for querying GitHub pulls
Added `PR_QUERY_OPTIONS` to be able to control PRs query parameters. 
Example: `per_page=100&sort=long-running&direction=descending`

See for more details https://docs.github.com/en/rest/reference/pulls#list-pull-requests

-  Added a new metric for long running PR requests - `PullRequestLongRunningCount`
 By default PRs are considered long running if not closed after two weeks. The threshold is controlled by `PR_LONG_RUNNING_TIME_DIFF`  env variable.
This metric is important for Wiley to track PRs that are open for long periods. With this we plan to provide feedback to owners of monitored repos so they can close outstanding PRs.

**Helm chart**
The chart helps with managing `github-exporter` deployments in Kubernetes. Integration with Prrometheus is achieved through the k8s `ServiceMonitor`.