### PR TITLE
Fix: Socket leaks if server returns RateLimitExceededStatus status.

### DIFF
--- a/exporter/http.go
+++ b/exporter/http.go
@@ -146,6 +146,7 @@ func getHTTPResponse(url string, token string) (*http.Response, error) {
 
 	// check rate limit exceeded.
 	if resp.Status == RateLimitExceededStatus {
+		resp.Body.Close()
 		return nil, fmt.Errorf("%s", resp.Status)
 	}
 


### PR DESCRIPTION
I'm not a guru in network applications on golang, so I'm not sure, but perhaps you should also always read the response body.

https://hackernoon.com/avoiding-memory-leak-in-golang-api-1843ef45fca8